### PR TITLE
Add MCP sample

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,10 @@ from langchain_huggingface import HuggingFacePipeline
 from langchain.prompts import PromptTemplate
 from langchain_core.runnables import RunnableSequence
 
+from mcp.client.stdio import stdio_client, StdioServerParameters
+from mcp.client.session import ClientSession
+import anyio
+
 # モデルのダウンロード（キャッシュに保存）
 model_path = snapshot_download(
     repo_id="bigscience/bloom-560m",
@@ -42,10 +46,26 @@ prompt = PromptTemplate(
 # RunnableSequence構成（プロンプト→LLM）
 chain: RunnableSequence = prompt | llm
 
+
+async def run_mcp(question: str) -> str:
+    """Call the MCP example server to answer the question."""
+    params = StdioServerParameters(command=sys.executable, args=["examples/mcp_server.py"])
+    async with stdio_client(params) as (read_stream, write_stream):
+        session = ClientSession(read_stream, write_stream)
+        await session.initialize()
+        result = await session.call_tool("ask_openai", {"prompt": question})
+        if result.isError:
+            return f"Error: {result.error}"
+        return result.content[0].text if result.content else ""
+
 if __name__ == "__main__":
     # 質問を入力
     q = input("質問を入力してください: ")
-    # 実行
+    # LangChain パイプラインの実行
     response = chain.invoke({"question": q})
-    # 結果表示
     print("AIの回答:", response)
+
+    # MCP 経由でも同じ質問を投げる例
+    print("\n--- MCP 経由の回答例 ---")
+    mcp_response = anyio.run(run_mcp, q)
+    print(mcp_response)


### PR DESCRIPTION
## Summary
- add MCP client imports in main
- show how to call MCP server from `main.py`
- display the response via MCP

## Testing
- `python3 -m py_compile main.py examples/mcp_client.py examples/mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68623d2921d083268bfc18621c27ff80